### PR TITLE
Correct example to match the latest version

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,15 @@ output as below.::
      S3=(1,2,3)
      L=(1,2)
      R=(1,3)
-    sage: QuadraticStratum(1,1,1,1).orientation_cover()
+    sage: q = QuadraticStratum(1,1,1,1)
+    sage: q.orientation_cover()
+    H_5(2^4)
+    sage: q.components()
+    [Q_2(1^4)^hyp]
+    sage: c = q.components()[0]
+    sage: c
+    Q_2(1^4)^hyp
+    sage: c.orientation_cover_component()
     H_5(2^4)^odd
 
     sage: AbelianStrata(genus=3).list()


### PR DESCRIPTION
The input  `QuadraticStratum(1,1,1,1).orientation_cover()` now outputs `H_5(2^4)` rather than the `H_5(2^4)^odd` given in the example. So we corrected this and then added the code that now outputs the `H_5(2^4)^odd` information.